### PR TITLE
fix: Replaced deprecated getchildren method

### DIFF
--- a/fsklib/output.py
+++ b/fsklib/output.py
@@ -182,7 +182,7 @@ class OdfParticOutput(OutputBase):
         accreditation_ids = []
         for person in persons:
             par_elem = self.competition_elem.find(f"./Participant/Discipline[@IFId='{person.id}']/..")
-            dis_elem = par_elem.getchildren()[0] # there is always only one child -> Discipline
+            dis_elem = list(par_elem)[0] # there is always only one child -> Discipline
             event_elem = ET.SubElement(dis_elem, "RegisteredEvent", {"Event" : self.get_discipline_code(category)})
             event_club_attrib = {
                 "Type" : "ER_EXTENDED",


### PR DESCRIPTION
Starting with Python 3.2, ET.getchildren() is depracted, removed in 3.9. Replaced with 'list(elem)' as recommended.

https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren